### PR TITLE
결제 환불일시 정보 추가 및 환불 멱등성 처리

### DIFF
--- a/backend/src/main/java/com/maru/controller/invoice/dto/PaymentRes.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/PaymentRes.java
@@ -14,7 +14,8 @@ public record PaymentRes(
         BigDecimal amount,
         PaymentMethod method,
         PaymentStatus status,
-        LocalDateTime paidAt
+        LocalDateTime paidAt,
+        LocalDateTime refundedAt
 ) {
 
     public static PaymentRes from(Payment payment) {
@@ -24,6 +25,7 @@ public record PaymentRes(
                 .method(payment.getMethod())
                 .status(payment.getStatus())
                 .paidAt(payment.getPaidAt())
+                .refundedAt(payment.getRefundedAt())
                 .build();
     }
 }

--- a/backend/src/main/java/com/maru/domain/invoice/Payment.java
+++ b/backend/src/main/java/com/maru/domain/invoice/Payment.java
@@ -78,6 +78,9 @@ public class Payment extends BaseTimeEntity {
     }
 
     public void refund() {
+        if (this.status == PaymentStatus.REFUNDED) {
+            return;
+        }
         this.status = PaymentStatus.REFUNDED;
         this.refundedAt = LocalDateTime.now();
     }

--- a/frontend/src/features/payments/components/PaymentList.tsx
+++ b/frontend/src/features/payments/components/PaymentList.tsx
@@ -53,6 +53,11 @@ export function PaymentList({ payments, onCancelPayment, canCancel }: PaymentLis
             <p className="text-xs text-muted-foreground">
               {formatDate(payment.paidAt)}
             </p>
+            {payment.status === 'REFUNDED' && payment.refundedAt && (
+              <p className="text-xs text-destructive">
+                환불: {formatDate(payment.refundedAt)}
+              </p>
+            )}
           </div>
 
           {canCancel && payment.status !== 'REFUNDED' && (

--- a/frontend/src/features/payments/types/index.ts
+++ b/frontend/src/features/payments/types/index.ts
@@ -21,6 +21,7 @@ export interface PaymentRes {
   method: PaymentMethod;
   status: PaymentStatus;
   paidAt: string;
+  refundedAt: string | null;
 }
 
 export interface InvoiceDetailRes {


### PR DESCRIPTION
## 1. 배경 및 목적

- 현황
  - 결제 환불 시 환불 시점(`refundedAt`)이 저장되지만 API 응답에 포함되지 않음
  - 사용자가 환불이 언제 처리되었는지 확인할 방법이 없음
  - 동일 결제에 대해 중복 환불 요청 시 `refundedAt`이 갱신되는 문제

- 목적
  - 환불 일시를 API 응답에 포함하여 사용자에게 환불 시점 정보 제공
  - 환불 로직에 멱등성 보장

## 2. 주요 변경 내용

### 2.1 결제 응답 DTO
- `PaymentRes`에 `refundedAt: LocalDateTime` 필드 추가
- 환불된 결제 조회 시 환불 시점 반환

### 2.2 환불 멱등성 처리
- `Payment.refund()` 메서드에 멱등성 로직 추가
- 이미 `REFUNDED` 상태인 경우 early return하여 중복 처리 방지

### 2.3 프론트엔드
- `PaymentRes` 타입에 `refundedAt` 필드 추가
- `PaymentList` 컴포넌트에서 환불 상태인 경우 환불 시간 표시
  - 포맷: "환불: 2026-01-02 14:30"

## 3. 테스트 및 검증

- [x] 백엔드 빌드 정상 확인
- [x] 프론트엔드 타입 체크 정상 확인
- [x] 환불 API 호출 시 `refundedAt` 응답 확인
- [x] 중복 환불 요청 시 기존 `refundedAt` 유지 확인

<img width="531" height="589" alt="image" src="https://github.com/user-attachments/assets/b919d5ce-35f5-43fb-ac80-5bb3beb1253a" />