### PR TITLE
청구 연월 필드 YearMonth 타입으로 통합

### DIFF
--- a/backend/src/main/java/com/maru/common/converter/YearMonthConverter.java
+++ b/backend/src/main/java/com/maru/common/converter/YearMonthConverter.java
@@ -1,0 +1,28 @@
+package com.maru.common.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.YearMonth;
+
+@Converter(autoApply = true)
+public class YearMonthConverter implements AttributeConverter<YearMonth, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(YearMonth yearMonth) {
+        if (yearMonth == null) {
+            return null;
+        }
+        return yearMonth.getYear() * 100 + yearMonth.getMonthValue();
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(Integer dbValue) {
+        if (dbValue == null) {
+            return null;
+        }
+        int year = dbValue / 100;
+        int month = dbValue % 100;
+        return YearMonth.of(year, month);
+    }
+}

--- a/backend/src/main/java/com/maru/common/exception/InvoiceErrorCode.java
+++ b/backend/src/main/java/com/maru/common/exception/InvoiceErrorCode.java
@@ -15,9 +15,7 @@ public enum InvoiceErrorCode implements BaseErrorCode {
     STUDENT_REQUIRED(HttpStatus.BAD_REQUEST, "INVOICE_101", "원생 정보는 필수입니다"),
     DUE_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "INVOICE_102", "납부 마감일은 필수입니다"),
     AMOUNT_REQUIRED(HttpStatus.BAD_REQUEST, "INVOICE_103", "청구 금액은 필수입니다"),
-
-    // 검증 실패
-    INVALID_BILLING_MONTH(HttpStatus.BAD_REQUEST, "INVOICE_201", "청구 월은 1-12 사이여야 합니다"),
+    BILLING_YEAR_MONTH_REQUIRED(HttpStatus.BAD_REQUEST, "INVOICE_104", "청구 연월은 필수입니다"),
 
     // 비즈니스 규칙 위반
     DUPLICATE_INVOICE(HttpStatus.CONFLICT, "INVOICE_301", "해당 월에 이미 청구서가 존재합니다"),

--- a/backend/src/main/java/com/maru/controller/invoice/dto/InvoiceBulkCreateReq.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/InvoiceBulkCreateReq.java
@@ -1,7 +1,5 @@
 package com.maru.controller.invoice.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -9,6 +7,7 @@ import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @Builder
@@ -25,9 +24,5 @@ public record InvoiceBulkCreateReq(
         @Size(max = 500, message = "비고는 500자 이내여야 합니다")
         String note,
 
-        Integer billingYear,
-
-        @Min(value = 1, message = "청구 월은 1 이상이어야 합니다")
-        @Max(value = 12, message = "청구 월은 12 이하여야 합니다")
-        Integer billingMonth
+        YearMonth billingYearMonth
 ) {}

--- a/backend/src/main/java/com/maru/controller/invoice/dto/InvoiceCreateReq.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/InvoiceCreateReq.java
@@ -1,7 +1,5 @@
 package com.maru.controller.invoice.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -9,6 +7,7 @@ import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 
 @Builder
 public record InvoiceCreateReq(
@@ -24,9 +23,5 @@ public record InvoiceCreateReq(
         @Size(max = 500, message = "비고는 500자 이내여야 합니다")
         String note,
 
-        Integer billingYear,
-
-        @Min(value = 1, message = "청구 월은 1 이상이어야 합니다")
-        @Max(value = 12, message = "청구 월은 12 이하여야 합니다")
-        Integer billingMonth
+        YearMonth billingYearMonth
 ) {}

--- a/backend/src/main/java/com/maru/controller/invoice/dto/InvoiceDetailRes.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/InvoiceDetailRes.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @Builder
@@ -20,8 +21,7 @@ public record InvoiceDetailRes(
         LocalDate dueDate,
         LocalDate issueDate,
         String note,
-        int billingYear,
-        int billingMonth,
+        YearMonth billingYearMonth,
         List<PaymentRes> payments
 ) {
 
@@ -37,8 +37,7 @@ public record InvoiceDetailRes(
                 .dueDate(invoice.getDueDate())
                 .issueDate(invoice.getIssueDate())
                 .note(invoice.getNote())
-                .billingYear(invoice.getBillingYear())
-                .billingMonth(invoice.getBillingMonth())
+                .billingYearMonth(invoice.getBillingYearMonth())
                 .payments(payments)
                 .build();
     }

--- a/backend/src/main/java/com/maru/controller/invoice/dto/InvoiceListRes.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/InvoiceListRes.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 
 @Builder
 public record InvoiceListRes(
@@ -17,8 +18,7 @@ public record InvoiceListRes(
         InvoiceStatus status,
         LocalDate dueDate,
         LocalDate issueDate,
-        int billingYear,
-        int billingMonth
+        YearMonth billingYearMonth
 ) {
 
     public static InvoiceListRes from(Invoice invoice) {
@@ -31,8 +31,7 @@ public record InvoiceListRes(
                 .status(invoice.getStatus())
                 .dueDate(invoice.getDueDate())
                 .issueDate(invoice.getIssueDate())
-                .billingYear(invoice.getBillingYear())
-                .billingMonth(invoice.getBillingMonth())
+                .billingYearMonth(invoice.getBillingYearMonth())
                 .build();
     }
 }

--- a/backend/src/main/java/com/maru/controller/invoice/dto/PrepaidPaymentReq.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/PrepaidPaymentReq.java
@@ -6,22 +6,17 @@ import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 
 public record PrepaidPaymentReq(
         @NotNull(message = "원생 ID는 필수입니다")
         String studentId,
 
-        @NotNull(message = "시작 연도는 필수입니다")
-        Integer startYear,
+        @NotNull(message = "시작 연월은 필수입니다")
+        YearMonth startYearMonth,
 
-        @NotNull(message = "시작 월은 필수입니다")
-        Integer startMonth,
-
-        @NotNull(message = "종료 연도는 필수입니다")
-        Integer endYear,
-
-        @NotNull(message = "종료 월은 필수입니다")
-        Integer endMonth,
+        @NotNull(message = "종료 연월은 필수입니다")
+        YearMonth endYearMonth,
 
         @NotNull(message = "월 수업료는 필수입니다")
         @Positive(message = "월 수업료는 0보다 커야 합니다")

--- a/backend/src/main/java/com/maru/controller/invoice/dto/StudentPaymentHistoryRes.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/StudentPaymentHistoryRes.java
@@ -3,6 +3,7 @@ package com.maru.controller.invoice.dto;
 import lombok.Builder;
 
 import java.math.BigDecimal;
+import java.time.YearMonth;
 import java.util.List;
 
 @Builder
@@ -17,8 +18,7 @@ public record StudentPaymentHistoryRes(
     public record PaymentHistoryItem(
             String paymentId,
             String invoiceId,
-            Integer billingYear,
-            Integer billingMonth,
+            YearMonth billingYearMonth,
             BigDecimal amount,
             String method,
             String status,

--- a/backend/src/main/java/com/maru/controller/invoice/dto/UnpaidListRes.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/UnpaidListRes.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 
 @Builder
 public record UnpaidListRes(
@@ -16,6 +17,5 @@ public record UnpaidListRes(
         BigDecimal remainingAmount,
         LocalDate dueDate,
         int overdueDays,
-        int billingYear,
-        int billingMonth
+        YearMonth billingYearMonth
 ) {}

--- a/backend/src/main/java/com/maru/domain/invoice/Invoice.java
+++ b/backend/src/main/java/com/maru/domain/invoice/Invoice.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.Optional;
 
 @Entity
@@ -30,11 +31,8 @@ public class Invoice extends BaseEntity {
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
 
-    @Column(nullable = false)
-    private int billingYear;
-
-    @Column(nullable = false)
-    private int billingMonth;
+    @Column(name = "billing_ym", nullable = false)
+    private YearMonth billingYearMonth;
 
     @Column(length = 13)
     private String issuedBy;
@@ -57,18 +55,17 @@ public class Invoice extends BaseEntity {
     @Column(length = 500)
     private String note;
 
-    private Invoice(Student student, int billingYear, int billingMonth,
+    private Invoice(Student student, YearMonth billingYearMonth,
                     BigDecimal amount, LocalDate dueDate, String note) {
         DomainAssert.notNull(student, InvoiceErrorCode.STUDENT_REQUIRED);
+        DomainAssert.notNull(billingYearMonth, InvoiceErrorCode.BILLING_YEAR_MONTH_REQUIRED);
         DomainAssert.notNull(dueDate, InvoiceErrorCode.DUE_DATE_REQUIRED);
         DomainAssert.notNull(amount, InvoiceErrorCode.AMOUNT_REQUIRED);
-        validateBillingMonth(billingMonth);
 
         this.tenantId = student.getTenantId();
         this.dojangId = student.getDojang().getId();
         this.student = student;
-        this.billingYear = billingYear;
-        this.billingMonth = billingMonth;
+        this.billingYearMonth = billingYearMonth;
         this.issueDate = null;
         this.dueDate = dueDate;
         this.status = InvoiceStatus.DRAFT;
@@ -77,15 +74,9 @@ public class Invoice extends BaseEntity {
         this.note = note;
     }
 
-    public static Invoice create(Student student, int billingYear, int billingMonth,
+    public static Invoice create(Student student, YearMonth billingYearMonth,
                                  BigDecimal amount, LocalDate dueDate, String note) {
-        return new Invoice(student, billingYear, billingMonth, amount, dueDate, note);
-    }
-
-    private void validateBillingMonth(int billingMonth) {
-        if (billingMonth < 1 || billingMonth > 12) {
-            throw new BusinessException(InvoiceErrorCode.INVALID_BILLING_MONTH);
-        }
+        return new Invoice(student, billingYearMonth, amount, dueDate, note);
     }
 
     public void issue(String issuedBy) {

--- a/backend/src/main/java/com/maru/repository/invoice/InvoiceRepository.java
+++ b/backend/src/main/java/com/maru/repository/invoice/InvoiceRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
@@ -59,28 +60,24 @@ public interface InvoiceRepository extends JpaRepository<Invoice, String> {
         WHERE i.tenantId = :tenantId
           AND i.dojangId = :dojangId
           AND i.student.id = :studentId
-          AND i.billingYear = :year
-          AND i.billingMonth = :month
+          AND i.billingYearMonth = :yearMonth
         """)
-    boolean existsByBillingYearAndMonth(
+    boolean existsByBillingYearMonth(
             @Param("tenantId") String tenantId,
             @Param("dojangId") String dojangId,
             @Param("studentId") String studentId,
-            @Param("year") int year,
-            @Param("month") int month);
+            @Param("yearMonth") YearMonth yearMonth);
 
     @Query("""
         SELECT i.student.id FROM Invoice i
         WHERE i.tenantId = :tenantId
           AND i.dojangId = :dojangId
-          AND i.billingYear = :year
-          AND i.billingMonth = :month
+          AND i.billingYearMonth = :yearMonth
         """)
-    List<String> findStudentIdsWithInvoiceByBillingYearAndMonth(
+    List<String> findStudentIdsWithInvoiceByBillingYearMonth(
             @Param("tenantId") String tenantId,
             @Param("dojangId") String dojangId,
-            @Param("year") int year,
-            @Param("month") int month);
+            @Param("yearMonth") YearMonth yearMonth);
 
     @Query("""
         SELECT i FROM Invoice i
@@ -114,13 +111,11 @@ public interface InvoiceRepository extends JpaRepository<Invoice, String> {
         FROM Invoice i
         WHERE i.tenantId = :tenantId
           AND i.dojangId = :dojangId
-          AND i.billingYear = :year
-          AND i.billingMonth = :month
+          AND i.billingYearMonth = :yearMonth
           AND i.status != 'VOID'
         """)
     InvoiceStatistics getStatistics(
             @Param("tenantId") String tenantId,
             @Param("dojangId") String dojangId,
-            @Param("year") int year,
-            @Param("month") int month);
+            @Param("yearMonth") YearMonth yearMonth);
 }

--- a/backend/src/main/java/com/maru/service/invoice/InvoiceService.java
+++ b/backend/src/main/java/com/maru/service/invoice/InvoiceService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -54,15 +55,12 @@ public class InvoiceService {
 
         Student student = findStudentAndValidate(request.studentId(), dojangId);
 
-        LocalDate now = LocalDate.now();
-        int billingYear = request.billingYear() != null ? request.billingYear() : now.getYear();
-        int billingMonth = request.billingMonth() != null ? request.billingMonth() : now.getMonthValue();
-
+        YearMonth billingYearMonth = resolveBillingYearMonth(request.billingYearMonth());
         BigDecimal amount = resolveAmount(request.amount());
-        Invoice invoice = createAndSaveInvoice(student, billingYear, billingMonth, amount, request.dueDate(), request.note());
+        Invoice invoice = createAndSaveInvoice(student, billingYearMonth, amount, request.dueDate(), request.note());
 
-        log.info("청구서 생성 완료: invoiceId={}, studentId={}, billingYear={}, billingMonth={}",
-                invoice.getId(), request.studentId(), billingYear, billingMonth);
+        log.info("청구서 생성 완료: invoiceId={}, studentId={}, billingYearMonth={}",
+                invoice.getId(), request.studentId(), billingYearMonth);
 
         return buildInvoiceDetailRes(invoice);
     }
@@ -80,20 +78,19 @@ public class InvoiceService {
         String tenantId = TenantContextHolder.getTenantId();
         validateDojangAccess(dojangId, tenantId);
 
-        int billingYear = resolveBillingYear(request.billingYear());
-        int billingMonth = resolveBillingMonth(request.billingMonth());
+        YearMonth billingYearMonth = resolveBillingYearMonth(request.billingYearMonth());
         BigDecimal amount = resolveAmount(request.defaultAmount());
 
         TargetStudentsResult targetResult = findAllTargetStudents(tenantId, dojangId, request);
         List<Student> eligibleStudents = excludeAlreadyInvoiced(
-                targetResult.students, tenantId, dojangId, billingYear, billingMonth);
+                targetResult.students, tenantId, dojangId, billingYearMonth);
 
         int createdCount = createInvoicesForStudents(
-                eligibleStudents, billingYear, billingMonth, amount, request.dueDate(), request.note());
+                eligibleStudents, billingYearMonth, amount, request.dueDate(), request.note());
         int skippedCount = targetResult.totalCount - createdCount;
 
-        log.info("일괄 청구서 생성 완료: dojangId={}, billingYear={}, billingMonth={}, created={}, skipped={}",
-                dojangId, billingYear, billingMonth, createdCount, skippedCount);
+        log.info("일괄 청구서 생성 완료: dojangId={}, billingYearMonth={}, created={}, skipped={}",
+                dojangId, billingYearMonth, createdCount, skippedCount);
 
         return BulkCreateRes.builder()
                 .createdCount(createdCount)
@@ -330,12 +327,8 @@ public class InvoiceService {
         return amount != null ? amount : BigDecimal.ZERO;
     }
 
-    private int resolveBillingYear(Integer year) {
-        return year != null ? year : LocalDate.now().getYear();
-    }
-
-    private int resolveBillingMonth(Integer month) {
-        return month != null ? month : LocalDate.now().getMonthValue();
+    private YearMonth resolveBillingYearMonth(YearMonth yearMonth) {
+        return yearMonth != null ? yearMonth : YearMonth.now();
     }
 
     private record TargetStudentsResult(List<Student> students, int totalCount) {}
@@ -355,9 +348,9 @@ public class InvoiceService {
     }
 
     private List<Student> excludeAlreadyInvoiced(List<Student> students, String tenantId, String dojangId,
-                                                  int billingYear, int billingMonth) {
-        List<String> existingStudentIds = invoiceRepository.findStudentIdsWithInvoiceByBillingYearAndMonth(
-                tenantId, dojangId, billingYear, billingMonth);
+                                                  YearMonth billingYearMonth) {
+        List<String> existingStudentIds = invoiceRepository.findStudentIdsWithInvoiceByBillingYearMonth(
+                tenantId, dojangId, billingYearMonth);
         Set<String> excludeIds = new HashSet<>(existingStudentIds);
 
         return students.stream()
@@ -365,9 +358,9 @@ public class InvoiceService {
                 .toList();
     }
 
-    private Invoice createAndSaveInvoice(Student student, int billingYear, int billingMonth,
+    private Invoice createAndSaveInvoice(Student student, YearMonth billingYearMonth,
                                          BigDecimal amount, LocalDate dueDate, String note) {
-        Invoice invoice = Invoice.create(student, billingYear, billingMonth, amount, dueDate, note);
+        Invoice invoice = Invoice.create(student, billingYearMonth, amount, dueDate, note);
         try {
             return invoiceRepository.save(invoice);
         } catch (DataIntegrityViolationException e) {
@@ -375,10 +368,10 @@ public class InvoiceService {
         }
     }
 
-    private int createInvoicesForStudents(List<Student> students, int billingYear, int billingMonth,
+    private int createInvoicesForStudents(List<Student> students, YearMonth billingYearMonth,
                                           BigDecimal amount, LocalDate dueDate, String note) {
         List<Invoice> invoices = students.stream()
-                .map(student -> Invoice.create(student, billingYear, billingMonth, amount, dueDate, note))
+                .map(student -> Invoice.create(student, billingYearMonth, amount, dueDate, note))
                 .toList();
         invoiceRepository.saveAll(invoices);
         return invoices.size();

--- a/backend/src/main/java/com/maru/service/invoice/PaymentService.java
+++ b/backend/src/main/java/com/maru/service/invoice/PaymentService.java
@@ -138,7 +138,7 @@ public class PaymentService {
                 tenantId, dojangId, startOfMonth, startOfNextMonth);
 
         InvoiceStatistics statistics = invoiceRepository.getStatistics(
-                tenantId, dojangId, year, month);
+                tenantId, dojangId, YearMonth.of(year, month));
 
         return PaymentStatisticsRes.builder()
                 .totalPaidAmount(totalPaidAmount)
@@ -183,8 +183,7 @@ public class PaymentService {
 
         Student student = findStudentAndValidate(request.studentId(), dojangId);
         List<YearMonth> months = calculateMonthRange(
-                request.startYear(), request.startMonth(),
-                request.endYear(), request.endMonth()
+                request.startYearMonth(), request.endYearMonth()
         );
         validateNoDuplicateInvoices(tenantId, dojangId, request.studentId(), months);
 
@@ -285,8 +284,7 @@ public class PaymentService {
                 .remainingAmount(invoice.getRemainingAmount())
                 .dueDate(invoice.getDueDate())
                 .overdueDays(calculateOverdueDays(invoice.getDueDate(), today))
-                .billingYear(invoice.getBillingYear())
-                .billingMonth(invoice.getBillingMonth())
+                .billingYearMonth(invoice.getBillingYearMonth())
                 .build();
     }
 
@@ -338,8 +336,7 @@ public class PaymentService {
         return StudentPaymentHistoryRes.PaymentHistoryItem.builder()
                 .paymentId(payment.getId())
                 .invoiceId(invoice.getId())
-                .billingYear(invoice.getBillingYear())
-                .billingMonth(invoice.getBillingMonth())
+                .billingYearMonth(invoice.getBillingYearMonth())
                 .amount(payment.getAmount())
                 .method(payment.getMethod() != null ? payment.getMethod().name() : null)
                 .status(payment.getStatus() != null ? payment.getStatus().name() : null)
@@ -349,10 +346,9 @@ public class PaymentService {
     }
 
 
-    private List<YearMonth> calculateMonthRange(int startYear, int startMonth, int endYear, int endMonth) {
+    private List<YearMonth> calculateMonthRange(YearMonth start, YearMonth end) {
         List<YearMonth> months = new ArrayList<>();
-        YearMonth current = YearMonth.of(startYear, startMonth);
-        YearMonth end = YearMonth.of(endYear, endMonth);
+        YearMonth current = start;
 
         while (!current.isAfter(end)) {
             months.add(current);
@@ -365,8 +361,8 @@ public class PaymentService {
 
     private void validateNoDuplicateInvoices(String tenantId, String dojangId, String studentId, List<YearMonth> months) {
         for (YearMonth ym : months) {
-            boolean exists = invoiceRepository.existsByBillingYearAndMonth(
-                    tenantId, dojangId, studentId, ym.getYear(), ym.getMonthValue()
+            boolean exists = invoiceRepository.existsByBillingYearMonth(
+                    tenantId, dojangId, studentId, ym
             );
             if (exists) {
                 throw new BusinessException(InvoiceErrorCode.PREPAID_DUPLICATE_INVOICE);
@@ -414,8 +410,7 @@ public class PaymentService {
     ) {
         Invoice invoice = Invoice.create(
                 student,
-                yearMonth.getYear(),
-                yearMonth.getMonthValue(),
+                yearMonth,
                 amount,
                 dueDate,
                 note

--- a/backend/src/main/resources/db/migration/V003__convert_billing_year_month_to_ym.sql
+++ b/backend/src/main/resources/db/migration/V003__convert_billing_year_month_to_ym.sql
@@ -1,0 +1,15 @@
+-- billing_year, billing_month를 billing_ym (YYYYMM 형식)으로 통합
+
+-- 기존 제약/인덱스 삭제
+ALTER TABLE invoice DROP INDEX uk_invoice_billing;
+DROP INDEX idx_invoice_billing ON invoice;
+
+-- 컬럼 변경
+ALTER TABLE invoice ADD COLUMN billing_ym INT NOT NULL;
+ALTER TABLE invoice DROP COLUMN billing_year;
+ALTER TABLE invoice DROP COLUMN billing_month;
+
+-- 새 제약/인덱스 생성
+ALTER TABLE invoice ADD CONSTRAINT uk_invoice_billing
+    UNIQUE (tenant_id, dojang_id, student_id, billing_ym);
+CREATE INDEX idx_invoice_billing ON invoice (tenant_id, dojang_id, billing_ym);


### PR DESCRIPTION
## 1. 배경 및 목적

현황:
- 청구서(Invoice)의 청구 연월이 `billingYear(int)` + `billingMonth(int)` 두 필드로 분리되어 있어, 쿼리 조건이 복잡하고 연월 범위 계산 로직이 산재함
목적:
`YearMonth` 타입으로 통합하여 타입 안전성 확보 및 쿼리/비즈니스 로직 단순화

## 2. 주요 변경 내용

### 2.1 YearMonthConverter 추가
- JPA `@Converter(autoApply = true)`로 `YearMonth ↔ Integer(YYYYMM)` 자동 변환
- DB에는 `202501` 형태로 저장, 코드에서는 `YearMonth.of(2025, 1)`로 사용

### 2.2 Entity 변경
| 변경 전 | 변경 후 |
|---------|---------|
| `billingYear: int` | `billingYearMonth: YearMonth` |
| `billingMonth: int` | (통합) |

### 2.3 DTO 변경
- `InvoiceCreateReq`, `InvoiceBulkCreateReq`: `billingYearMonth: YearMonth`
- `PrepaidPaymentReq`: `startYearMonth`, `endYearMonth: YearMonth`
- Response DTO들: `billingYearMonth` 단일 필드로 통합

### 2.4 Repository/Service 리팩토링
- `existsByBillingYearAndMonth()` → `existsByBillingYearMonth(YearMonth)`
- `findStudentIdsWithInvoiceByBillingYearAndMonth()` → `findStudentIdsWithInvoiceByBillingYearMonth(YearMonth)`
- `getStatistics(year, month)` → `getStatistics(YearMonth)`

### 2.5 DB 마이그레이션 (V003)
- `billing_year`, `billing_month` 컬럼 → `billing_year_month` 컬럼 변환

## 3. 테스트 및 검증

- [x] 빌드 및 컴파일 정상 확인
- [x] 청구서 생성/조회 API 테스트
- [x] 선납 수납 API 테스트

<img width="1900" height="112" alt="image" src="https://github.com/user-attachments/assets/c7f8e4d1-5130-4d49-8e22-3d331e9a4c63" />

## 4. 참고사항

- 커밋 로그는 interactive rebase 로 새롭게 작성됨 (리뷰 후 기존 커밋 로그 복구 예정)

