### PR TITLE
연간 수납 통계 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/maru/controller/invoice/dto/MonthlyStatisticsData.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/MonthlyStatisticsData.java
@@ -1,0 +1,25 @@
+package com.maru.controller.invoice.dto;
+
+import java.math.BigDecimal;
+
+public record MonthlyStatisticsData(
+        int month,
+        BigDecimal totalAmount,
+        BigDecimal paidAmount,
+        BigDecimal unpaidAmount,
+        int paidCount,
+        int unpaidCount,
+        int partialCount
+) {
+    public static MonthlyStatisticsData zero(int month) {
+        return new MonthlyStatisticsData(
+                month,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                0,
+                0,
+                0
+        );
+    }
+}

--- a/backend/src/main/java/com/maru/controller/invoice/dto/YearlyStatisticsRes.java
+++ b/backend/src/main/java/com/maru/controller/invoice/dto/YearlyStatisticsRes.java
@@ -1,0 +1,17 @@
+package com.maru.controller.invoice.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+public record YearlyStatisticsRes(
+        int year,
+        BigDecimal totalPaidAmount,
+        BigDecimal totalUnpaidAmount,
+        int paidInvoiceCount,
+        int unpaidInvoiceCount,
+        int partialInvoiceCount,
+        List<MonthlyStatisticsData> monthlyData
+) {}

--- a/backend/src/main/java/com/maru/controller/payment/PaymentController.java
+++ b/backend/src/main/java/com/maru/controller/payment/PaymentController.java
@@ -3,6 +3,7 @@ package com.maru.controller.payment;
 import com.maru.controller.invoice.dto.PaymentStatisticsRes;
 import com.maru.controller.invoice.dto.StudentPaymentHistoryRes;
 import com.maru.controller.invoice.dto.UnpaidListRes;
+import com.maru.controller.invoice.dto.YearlyStatisticsRes;
 import com.maru.security.CurrentUserId;
 import com.maru.service.invoice.PaymentService;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +54,23 @@ public class PaymentController {
             @RequestParam int month,
             @CurrentUserId String userId) {
         PaymentStatisticsRes response = paymentService.getPaymentStatistics(dojangId, year, month);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 연간 수납 통계 조회 API
+     *
+     * @param dojangId 도장 ID
+     * @param year 조회 연도
+     * @param userId 현재 인증된 사용자 ID
+     * @return 연간 수납 통계 (월별 데이터 포함)
+     */
+    @GetMapping("/statistics/year")
+    public ResponseEntity<YearlyStatisticsRes> getYearStatistics(
+            @RequestParam String dojangId,
+            @RequestParam int year,
+            @CurrentUserId String userId) {
+        YearlyStatisticsRes response = paymentService.getYearStatistics(dojangId, year);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/maru/repository/invoice/InvoiceRepository.java
+++ b/backend/src/main/java/com/maru/repository/invoice/InvoiceRepository.java
@@ -3,6 +3,7 @@ package com.maru.repository.invoice;
 import com.maru.domain.invoice.Invoice;
 import com.maru.domain.invoice.InvoiceStatus;
 import com.maru.repository.invoice.projection.InvoiceStatistics;
+import com.maru.repository.invoice.projection.MonthlyInvoiceStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -118,4 +119,28 @@ public interface InvoiceRepository extends JpaRepository<Invoice, String> {
             @Param("tenantId") String tenantId,
             @Param("dojangId") String dojangId,
             @Param("yearMonth") YearMonth yearMonth);
+
+    @Query("""
+        SELECT
+            i.billingYearMonth AS yearMonth,
+            COALESCE(SUM(i.amount), 0) AS totalAmount,
+            COALESCE(SUM(i.paidAmount), 0) AS totalPaidAmount,
+            COALESCE(SUM(CASE WHEN i.status IN ('OPEN', 'PARTIAL') THEN i.amount - i.paidAmount ELSE 0 END), 0) AS totalUnpaidAmount,
+            COUNT(CASE WHEN i.status = 'PAID' THEN 1 END) AS paidCount,
+            COUNT(CASE WHEN i.status = 'PARTIAL' THEN 1 END) AS partialCount,
+            COUNT(CASE WHEN i.status IN ('OPEN', 'PARTIAL') THEN 1 END) AS unpaidCount
+        FROM Invoice i
+        WHERE i.tenantId = :tenantId
+          AND i.dojangId = :dojangId
+          AND i.billingYearMonth >= :startYearMonth
+          AND i.billingYearMonth <= :endYearMonth
+          AND i.status != 'VOID'
+        GROUP BY i.billingYearMonth
+        ORDER BY i.billingYearMonth
+        """)
+    List<MonthlyInvoiceStatistics> getYearStatistics(
+            @Param("tenantId") String tenantId,
+            @Param("dojangId") String dojangId,
+            @Param("startYearMonth") YearMonth startYearMonth,
+            @Param("endYearMonth") YearMonth endYearMonth);
 }

--- a/backend/src/main/java/com/maru/repository/invoice/projection/MonthlyInvoiceStatistics.java
+++ b/backend/src/main/java/com/maru/repository/invoice/projection/MonthlyInvoiceStatistics.java
@@ -1,0 +1,14 @@
+package com.maru.repository.invoice.projection;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+
+public interface MonthlyInvoiceStatistics {
+    YearMonth getYearMonth();
+    BigDecimal getTotalAmount();
+    BigDecimal getTotalPaidAmount();
+    BigDecimal getTotalUnpaidAmount();
+    int getPaidCount();
+    int getPartialCount();
+    int getUnpaidCount();
+}

--- a/backend/src/main/java/com/maru/service/invoice/PaymentService.java
+++ b/backend/src/main/java/com/maru/service/invoice/PaymentService.java
@@ -17,6 +17,7 @@ import com.maru.repository.guardian.GuardianshipRepository;
 import com.maru.repository.invoice.InvoiceRepository;
 import com.maru.repository.invoice.PaymentRepository;
 import com.maru.repository.invoice.projection.InvoiceStatistics;
+import com.maru.repository.invoice.projection.MonthlyInvoiceStatistics;
 import com.maru.repository.student.StudentRepository;
 import com.maru.repository.tenant.DojangRepository;
 import com.maru.security.TenantContextHolder;
@@ -147,6 +148,75 @@ public class PaymentService {
                 .unpaidInvoiceCount((int) statistics.getUnpaidCount())
                 .partialInvoiceCount((int) statistics.getPartialCount())
                 .build();
+    }
+
+    /**
+     * 연간 수납 통계 조회
+     *
+     * @param dojangId 도장 ID
+     * @param year 조회 연도
+     * @return 연간 통계 (월별 데이터 포함)
+     */
+    @Transactional(readOnly = true)
+    public YearlyStatisticsRes getYearStatistics(String dojangId, int year) {
+        String tenantId = TenantContextHolder.getTenantId();
+        validateDojangAccess(dojangId, tenantId);
+
+        YearMonth startYearMonth = YearMonth.of(year, 1);
+        YearMonth endYearMonth = YearMonth.of(year, 12);
+
+        List<MonthlyInvoiceStatistics> queryResult = invoiceRepository.getYearStatistics(
+                tenantId, dojangId, startYearMonth, endYearMonth);
+
+        List<MonthlyStatisticsData> monthlyData = buildMonthlyDataWithZeroFilling(year, queryResult);
+
+        BigDecimal totalPaidAmount = monthlyData.stream()
+                .map(MonthlyStatisticsData::paidAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalUnpaidAmount = monthlyData.stream()
+                .map(MonthlyStatisticsData::unpaidAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        int paidCount = monthlyData.stream().mapToInt(MonthlyStatisticsData::paidCount).sum();
+        int unpaidCount = monthlyData.stream().mapToInt(MonthlyStatisticsData::unpaidCount).sum();
+        int partialCount = monthlyData.stream().mapToInt(MonthlyStatisticsData::partialCount).sum();
+
+        return YearlyStatisticsRes.builder()
+                .year(year)
+                .totalPaidAmount(totalPaidAmount)
+                .totalUnpaidAmount(totalUnpaidAmount)
+                .paidInvoiceCount(paidCount)
+                .unpaidInvoiceCount(unpaidCount)
+                .partialInvoiceCount(partialCount)
+                .monthlyData(monthlyData)
+                .build();
+    }
+
+    private List<MonthlyStatisticsData> buildMonthlyDataWithZeroFilling(
+            int year, List<MonthlyInvoiceStatistics> queryResult) {
+        Map<Integer, MonthlyInvoiceStatistics> resultMap = queryResult.stream()
+                .collect(Collectors.toMap(
+                        stat -> stat.getYearMonth().getMonthValue(),
+                        stat -> stat
+                ));
+
+        List<MonthlyStatisticsData> monthlyData = new ArrayList<>();
+        for (int month = 1; month <= 12; month++) {
+            MonthlyInvoiceStatistics stat = resultMap.get(month);
+            if (stat != null) {
+                monthlyData.add(new MonthlyStatisticsData(
+                        month,
+                        stat.getTotalAmount(),
+                        stat.getTotalPaidAmount(),
+                        stat.getTotalUnpaidAmount(),
+                        stat.getPaidCount(),
+                        stat.getUnpaidCount(),
+                        stat.getPartialCount()
+                ));
+            } else {
+                monthlyData.add(MonthlyStatisticsData.zero(month));
+            }
+        }
+        return monthlyData;
     }
 
     /**


### PR DESCRIPTION
## 1. 배경 및 목적

현황:
- 연간 통계 조회 시 프론트엔드에서 월별 API를 12번 호출하여 비효율적
목적:
- 단일 API 호출로 12개월 통계를 한 번에 조회하여 성능 최적화

## 2. 주요 변경 내용

### 2.1 새로운 API 엔드포인트

| 메서드 | 경로 | 설명 |
|--------|------|------|
| GET | `/api/v1/payments/statistics/year` | 연간 수납 통계 조회 |

**Request Parameters:**
- `dojangId`: 도장 ID
- `year`: 조회 연도

**Response:**
```json
{
  "year": 2025,
  "totalPaidAmount": 12000000,
  "totalUnpaidAmount": 500000,
  "paidInvoiceCount": 120,
  "unpaidInvoiceCount": 5,
  "partialInvoiceCount": 3,
  "monthlyData": [
    { "month": 1, "totalAmount": 1000000, "paidAmount": 950000, ... },
    ...
  ]
}
```

### 2.2 DTO 추가

- YearlyStatisticsRes: 연간 통계 응답
- MonthlyStatisticsData: 월별 통계 데이터 (record)

### 2.3 Repository 쿼리 추가

- getYearStatistics(): GROUP BY 월별 집계 쿼리
- MonthlyInvoiceStatistics: Interface Projection

### 2.4 Service 로직

- PaymentService.getYearStatistics(): 연간 통계 조회
- Zero-filling 처리: 데이터 없는 월도 0으로 반환 (1~12월 완전한 배열)

## 3. 테스트 및 검증

- [x] 빌드 및 컴파일 정상 확인
- [x] 연간 통계 API 호출 테스트
- [x] 데이터 없는 월 Zero-filling 확인

<img width="1389" height="1175" alt="image" src="https://github.com/user-attachments/assets/79eeadbf-960b-4853-97db-baa8455bb5a2" />
<img width="679" height="332" alt="image" src="https://github.com/user-attachments/assets/eea61a93-bb60-4ee4-91a3-18887c7f6b48" />


## 4. 참고사항

- 커밋 로그는 interactive rebase 로 새롭게 작성됨 (리뷰 후 기존 커밋 로그 복구 예정)